### PR TITLE
Youtube (Js API) URI redirect to Error 404

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -4061,7 +4061,7 @@ tarteaucitron.services.youtubeapi = {
     "key": "youtubeapi",
     "type": "video",
     "name": "Youtube (Js API)",
-    "uri": "https://policies.google.com/privacy/",
+    "uri": "https://policies.google.com/privacy",
     "needConsent": true,
     "cookies": [],
     "js": function () {


### PR DESCRIPTION
Error 404 (Introuvable)!!1
L'URL demandée est introuvable sur ce serveur.